### PR TITLE
Create README.rst using pandoc in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,16 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-install:
-- pip install .
-script:
-- python -m unittest discover -s tests
-- pandoc --to rst -o README.rst README.md
-- python setup.py sdist
-- tar -tf dist/rainflow-2.0.0.tar.gz
 addons:
   apt:
     packages:
       - pandoc
+install:
+- pip install .
+script:
+- python -m unittest discover -s tests
+before_deploy:
+- pandoc --to rst -o README.rst README.md
 deploy:
   provider: pypi
   user: iamlikeme

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ install:
 - pip install .
 script:
 - python -m unittest discover -s tests
+- pandoc --to rst -o README.rst README.md
+- python setup.py sdist
+addons:
+  apt:
+    packages:
+      - pandoc
 deploy:
   provider: pypi
   user: iamlikeme

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 - python -m unittest discover -s tests
 - pandoc --to rst -o README.rst README.md
 - python setup.py sdist
+- tar -tf dist/rainflow-2.0.0.tar.gz
 addons:
   apt:
     packages:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
+include README.rst
 include LICENSE
 include MANIFEST.in
 include tests/*.py


### PR DESCRIPTION
Package description from README.md does not show in PyPI, because PyPI requires readme in rst format.

Travis CI is now used to create README.rst using pandoc and include it in the distribution before deploying to PyPI.