### PR TITLE
Add conda-forge installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,21 @@ Supports both Python 2 and 3.
 Installation
 ------------
 
+`rainflow` is available [on PyPI](https://pypi.org/project/rainflow/):
+
 ```
 pip install rainflow
 ```
 
+and [on conda-forge](https://github.com/conda-forge/rainflow-feedstock):
+
+```
+conda install rainflow --channel conda-forge
+```
+
 Usage
 -----
+
 Let's generate a sample time series of some load. Here we create a numpy array but any iterable of numbers would work:
 ```python
 >>> import numpy as np


### PR DESCRIPTION
Hi, @iamlikeme 
I [contributed a recipe](https://github.com/conda-forge/rainflow-feedstock) to conda-forge, so that folks can now install `rainflow` using conda as well as pip. Added a couple of lines in README to reflect this. 

Currently I am the sole maintainer of the conda-forge recipe. Let me know if you would like to [be represented there](https://github.com/conda-forge/rainflow-feedstock/blob/4e0e46591b2cb90380486d5c7ea92badf37e1c22/recipe/meta.yaml#L42) as well. I think it would make sense. It entails negligible to zero work.

Cheers for a useful package!
JF
