### PR TITLE
Remove optional args "left" and "right" and change default behavior to left/right=True

### DIFF
--- a/src/rainflow.py
+++ b/src/rainflow.py
@@ -26,22 +26,17 @@ def _get_round_function(ndigits=None):
     return func
 
 
-def reversals(series, left=False, right=False):
+def reversals(series):
     """Iterate reversal points in the series.
 
     A reversal point is a point in the series at which the first derivative
     changes sign. Reversal is undefined at the first (last) point because the
     derivative before (after) this point is undefined. The first and the last
-    points may be treated as reversals by setting the optional parameters
-    `left` and `right` to True.
+    points are treated as reversals.
 
     Parameters
     ----------
     series : iterable sequence of numbers
-    left: bool, optional
-        If True, yield the first point in the series (treat it as a reversal).
-    right: bool, optional
-        If True, yield the last point in the series (treat it as a reversal).
 
     Yields
     ------
@@ -53,8 +48,7 @@ def reversals(series, left=False, right=False):
     x_last, x = next(series), next(series)
     d_last = (x - x_last)
 
-    if left:
-        yield x_last
+    yield x_last
     for x_next in series:
         if x_next == x:
             continue
@@ -63,8 +57,7 @@ def reversals(series, left=False, right=False):
             yield x
         x_last, x = x, x_next
         d_last = d_next
-    if right:
-        yield x_next
+    yield x_next
 
 
 def _sort_lows_and_highs(func):
@@ -80,16 +73,12 @@ def _sort_lows_and_highs(func):
 
 
 @_sort_lows_and_highs
-def extract_cycles(series, left=False, right=False):
+def extract_cycles(series):
     """Iterate cycles in the series.
 
     Parameters
     ----------
     series : iterable sequence of numbers
-    left: bool, optional
-        If True, treat the first point in the series as a reversal.
-    right: bool, optional
-        If True, treat the last point in the series as a reversal.
 
     Yields
     ------
@@ -100,7 +89,7 @@ def extract_cycles(series, left=False, right=False):
     """
     points = deque()
 
-    for x in reversals(series, left=left, right=right):
+    for x in reversals(series):
         points.append(x)
         while len(points) >= 3:
             # Form ranges X and Y from the three most recent points
@@ -129,7 +118,7 @@ def extract_cycles(series, left=False, right=False):
             points.popleft()
 
 
-def count_cycles(series, ndigits=None, nbins=None, binsize=None, left=False, right=False):
+def count_cycles(series, ndigits=None, nbins=None, binsize=None):
     """Count cycles in the series.
 
     Parameters
@@ -141,14 +130,10 @@ def count_cycles(series, ndigits=None, nbins=None, binsize=None, left=False, rig
         Specifies the number of cycle-counting bins
     binsize : int, optional
         Specifies the width of each cycle-counting bin
-    left: bool, optional
-        If True, treat the first point in the series as a reversal.
-    right: bool, optional
-        If True, treat the last point in the series as a reversal.
 
-    ndigits, nbins and binsize are mutually exclusive - only one of the three can
-    be specified
-    
+    ndigits, nbins and binsize are mutually exclusive - only one of the three
+    can be specified.
+
     Returns
     -------
     A sorted list containing pairs of cycle magnitude and count.
@@ -174,7 +159,7 @@ def count_cycles(series, ndigits=None, nbins=None, binsize=None, left=False, rig
 
     # if neither nbins nor binsize is specified
     if (nbins is None) and (binsize is None):
-        for low, high, mult in extract_cycles(series, left=left, right=right):
+        for low, high, mult in extract_cycles(series):
             delta = round_(abs(high - low))
             counts[delta] += mult
     else:
@@ -190,7 +175,7 @@ def count_cycles(series, ndigits=None, nbins=None, binsize=None, left=False, rig
         counts_ix = defaultdict(int)
         for i in range(nbins):
             counts_ix[i] = 0
-        for low, high, mult in extract_cycles(series, left=left, right=right):
+        for low, high, mult in extract_cycles(series):
             binIndex = int(abs(high - low) / binsize)
             # handle possibility of range equaliing max range
             if binIndex == nbins:
@@ -198,5 +183,5 @@ def count_cycles(series, ndigits=None, nbins=None, binsize=None, left=False, rig
             counts_ix[binIndex] += mult
         # save count data to dictionary where key is the range
         counts = dict(((k+1)*binsize,v) for k,v in counts_ix.items())
-    
+
     return sorted(counts.items())

--- a/tests/test_rainflow.py
+++ b/tests/test_rainflow.py
@@ -26,14 +26,14 @@ def test_count_cycles_ndigits(series, counts):
 
 
 def test_count_cycles_nbins(series):
-    assert rainflow.count_cycles(series, nbins=1) == [(9, 5.0)]
+    assert rainflow.count_cycles(series, nbins=1) == [(9, 4.0)]
     assert rainflow.count_cycles(series, nbins=2) == [
-        (4.5, 3.0),
+        (4.5, 2.0),
         (9.0, 2.0),
     ]
     assert rainflow.count_cycles(series, nbins=5) == [
         (1.8, 0.0),
-        (3.6, 1.5),
+        (3.6, 0.5),
         (5.4, 1.5),
         (7.2, 0.5),
         (9.0, 1.5),
@@ -41,7 +41,7 @@ def test_count_cycles_nbins(series):
     assert rainflow.count_cycles(series, nbins=9) == [
         (1.0, 0.0),
         (2.0, 0.0),
-        (3.0, 1.0),
+        (3.0, 0.0),
         (4.0, 0.5),
         (5.0, 1.5),
         (6.0, 0.0),
@@ -52,7 +52,7 @@ def test_count_cycles_nbins(series):
     assert rainflow.count_cycles(series, nbins=10) == [
         (0.9, 0.0),
         (1.8, 0.0),
-        (2.7, 1.0),
+        (2.7, 0.0),
         (3.6, 0.5),
         (4.5, 1.5),
         (5.4, 0.0),
@@ -64,20 +64,20 @@ def test_count_cycles_nbins(series):
 
 
 def test_count_cycles_binsize(series):
-    assert rainflow.count_cycles(series, binsize=10) == [(10, 5.0)]
-    assert rainflow.count_cycles(series, binsize=9) == [(9, 5.0)]
+    assert rainflow.count_cycles(series, binsize=10) == [(10, 4.0)]
+    assert rainflow.count_cycles(series, binsize=9) == [(9, 4.0)]
     assert rainflow.count_cycles(series, binsize=5) == [
-        (5, 3.0),
+        (5, 2.0),
         (10, 2.0),
     ]
     assert rainflow.count_cycles(series, binsize=3) == [
-        (3, 1.0),
+        (3, 0.0),
         (6, 2.0),
         (9, 2.0),
     ]
     assert rainflow.count_cycles(series, binsize=2) == [
         (2, 0.0),
-        (4, 1.5),
+        (4, 0.5),
         (6, 1.5),
         (8, 0.5),
         (10, 1.5),
@@ -85,7 +85,7 @@ def test_count_cycles_binsize(series):
     assert rainflow.count_cycles(series, binsize=1) == [
         (1, 0.0),
         (2, 0.0),
-        (3, 1.0),
+        (3, 0.0),
         (4, 0.5),
         (5, 1.5),
         (6, 0.0),
@@ -113,7 +113,6 @@ def test_extract_cycles_order_of_half_cycles(series):
         for low, high, mult in rainflow.extract_cycles(series)
     ]
     expected = [
-        (-1.0, 0.5),
         (-0.5, 0.5),
         (-1.0, 0.5),
         (1.0, 1.0),
@@ -121,6 +120,5 @@ def test_extract_cycles_order_of_half_cycles(series):
         (0.5, 0.5),
         (0.0, 0.5),
         (1.0, 0.5),
-        (-1.0, 0.5),
     ]
     assert result == expected

--- a/tests/test_rainflow.py
+++ b/tests/test_rainflow.py
@@ -6,7 +6,7 @@ import random
 
 @pytest.fixture
 def series():
-    return [0, -2, 1, -3, 5, -1, 3, -4, 4, -2, 0]
+    return [-2, 1, -3, 5, -1, 3, -4, 4, -2]
 
 
 @pytest.fixture
@@ -19,21 +19,6 @@ def test_count_cycles(series, counts):
     assert result == counts
 
 
-def test_count_cycles_left(series, counts):
-    result = rainflow.count_cycles(series[1:], left=True)
-    assert result == counts
-
-
-def test_count_cycles_right(series, counts):
-    result = rainflow.count_cycles(series[:-1], right=True)
-    assert result == counts
-
-
-def test_count_cycles_left_right(series, counts):
-    result = rainflow.count_cycles(series[1:-1], left=True, right=True)
-    assert result == counts
-
-
 def test_count_cycles_ndigits(series, counts):
     series = [x + 0.01 * random.random() for x in series]
     assert rainflow.count_cycles(series) != counts
@@ -41,21 +26,19 @@ def test_count_cycles_ndigits(series, counts):
 
 
 def test_count_cycles_nbins(series):
-    kwargs = {"left": True, "right": True}
-
-    assert rainflow.count_cycles(series, nbins=1, **kwargs) == [(9, 5.0)]
-    assert rainflow.count_cycles(series, nbins=2, **kwargs) == [
+    assert rainflow.count_cycles(series, nbins=1) == [(9, 5.0)]
+    assert rainflow.count_cycles(series, nbins=2) == [
         (4.5, 3.0),
         (9.0, 2.0),
     ]
-    assert rainflow.count_cycles(series, nbins=5, **kwargs) == [
+    assert rainflow.count_cycles(series, nbins=5) == [
         (1.8, 0.0),
         (3.6, 1.5),
         (5.4, 1.5),
         (7.2, 0.5),
         (9.0, 1.5),
     ]
-    assert rainflow.count_cycles(series, nbins=9, **kwargs) == [
+    assert rainflow.count_cycles(series, nbins=9) == [
         (1.0, 0.0),
         (2.0, 0.0),
         (3.0, 1.0),
@@ -66,7 +49,7 @@ def test_count_cycles_nbins(series):
         (8.0, 0.0),
         (9.0, 1.5),
     ]
-    assert rainflow.count_cycles(series, nbins=10, **kwargs) == [
+    assert rainflow.count_cycles(series, nbins=10) == [
         (0.9, 0.0),
         (1.8, 0.0),
         (2.7, 1.0),
@@ -81,27 +64,25 @@ def test_count_cycles_nbins(series):
 
 
 def test_count_cycles_binsize(series):
-    kwargs = {"left": True, "right": True}
-
-    assert rainflow.count_cycles(series, binsize=10, **kwargs) == [(10, 5.0)]
-    assert rainflow.count_cycles(series, binsize=9, **kwargs) == [(9, 5.0)]
-    assert rainflow.count_cycles(series, binsize=5, **kwargs) == [
+    assert rainflow.count_cycles(series, binsize=10) == [(10, 5.0)]
+    assert rainflow.count_cycles(series, binsize=9) == [(9, 5.0)]
+    assert rainflow.count_cycles(series, binsize=5) == [
         (5, 3.0),
         (10, 2.0),
     ]
-    assert rainflow.count_cycles(series, binsize=3, **kwargs) == [
+    assert rainflow.count_cycles(series, binsize=3) == [
         (3, 1.0),
         (6, 2.0),
         (9, 2.0),
     ]
-    assert rainflow.count_cycles(series, binsize=2, **kwargs) == [
+    assert rainflow.count_cycles(series, binsize=2) == [
         (2, 0.0),
         (4, 1.5),
         (6, 1.5),
         (8, 0.5),
         (10, 1.5),
     ]
-    assert rainflow.count_cycles(series, binsize=1, **kwargs) == [
+    assert rainflow.count_cycles(series, binsize=1) == [
         (1, 0.0),
         (2, 0.0),
         (3, 1.0),
@@ -129,9 +110,7 @@ def test_extract_cycles_low_high_is_sorted(series):
 def test_extract_cycles_order_of_half_cycles(series):
     result = [
         (0.5 * (high + low), mult)
-        for low, high, mult in rainflow.extract_cycles(
-            series, left=True, right=True
-        )
+        for low, high, mult in rainflow.extract_cycles(series)
     ]
     expected = [
         (-1.0, 0.5),


### PR DESCRIPTION
Until now, the default behavior of the `extract_cycles` function was to treat the first and the last point in the time series as non-reversals. The rationale was that in these points it is not possible to determine whether the gradient has changed sign. However, this behavior turned out to be unexpected for users, as attested by issues #4, #9, #29. Some other issues often and even many unit tests use non-default behavior (`left=True` and `right=True`).

Therefore, it seems reasonable to change the default behavior, such that the first and the last point in the time series are treated as reversals. It also seems unnecessary to keep the `left` and `right` arguments around. If needed, the effect of left/right=False can be achieved simply by dropping the first and the last point from the time series.