### PR TITLE
Do not run publish-to-pypi workflow on push to main

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,8 +2,6 @@ name: Publish Python distributions to PyPI and TestPyPI
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
   workflow_dispatch:


### PR DESCRIPTION
Workflow `.github/workflows/publish-to-pypi.yml` is triggered by pushed tags or manually.