### PR TITLE
Do not rely on importlib.metadata to get rainflow.__version__

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -46,7 +46,7 @@ files = [
 name = "importlib-metadata"
 version = "2.1.2"
 description = "Read metadata from Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 files = [
@@ -173,7 +173,7 @@ files = [
 name = "zipp"
 version = "1.2.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7"
 files = [
@@ -188,4 +188,4 @@ testing = ["func-timeout", "jaraco.itertools", "pathlib2", "unittest2"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7"
-content-hash = "83aee7cf046d2cd15cf3a53f79f3ec43e92932bf791a6f4543a53a5f5b8d0d62"
+content-hash = "f060c82905f13d620ba562410bcfd95497dbfbc36f913a6f263d472b4f8269a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-importlib_metadata = { version = "*", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = [
@@ -31,6 +30,7 @@ pytest = [
     { version = "*", python = "~3" },
     { version = "^6.2.5", python = "~3.10" },
 ]
+importlib_metadata = { version = "*", python = "<3.8" }
 more-itertools = { version = "<6", python = "~2.7" }
 
 [build-system]

--- a/src/rainflow.py
+++ b/src/rainflow.py
@@ -7,12 +7,7 @@ from __future__ import division
 from collections import deque, defaultdict
 import math
 
-try:
-    from importlib import metadata as _importlib_metadata
-except ImportError:
-    import importlib_metadata as _importlib_metadata
-
-__version__ = _importlib_metadata.version("rainflow")
+__version__ = "3.1.1"
 
 
 def _get_round_function(ndigits=None):

--- a/tests/test_rainflow.py
+++ b/tests/test_rainflow.py
@@ -4,6 +4,11 @@ import rainflow
 import random
 import math
 
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata as importlib_metadata
+
 # A test case is a tuple containing the following items:
 #  - a list representing a time series
 #  - a list of tuples, each containing:
@@ -107,6 +112,11 @@ TEST_CASE_3 = (
     ],
     True,
 )
+
+
+def test_version():
+    # Ensure that rainflow.__version__ is the same as version set in pyproject.toml
+    assert rainflow.__version__ == importlib_metadata.version("rainflow")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The version is now hard-coded in `rainflow.py` and a test is added to make sure that it matches version set in `pyproject.toml`. It allows to remove one dependency, `importlib-metadata`, which was required for Python 3.8.