### PR TITLE
Drop support for Python 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rainflow
 [![Test rainflow](https://github.com/iamlikeme/rainflow/actions/workflows/tests.yml/badge.svg)](https://github.com/iamlikeme/rainflow/actions/workflows/tests.yml)
 
 `rainflow` is a Python implementation of the ASTM E1049-85 rainflow cycle counting
-algorythm for fatigue analysis. Supports both Python 2 and 3.
+algorythm for fatigue analysis.
 
 Installation
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -23,7 +22,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python = ">=3.7"
 importlib_metadata = { version = "*", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
It is an increasing challenge to support Python 2, mainly because to tooling does not support it anymore.